### PR TITLE
Add comments and Clover name changes to logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1999,6 +1999,11 @@
         "vinyl": "^1.0.0"
       },
       "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        },
         "vinyl": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
@@ -3778,6 +3783,11 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
     },
@@ -3823,6 +3833,11 @@
             "hash.js": "^1.0.0",
             "inherits": "^2.0.1"
           }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
     },
@@ -10403,6 +10418,13 @@
       "requires": {
         "os-tmpdir": "^1.0.0",
         "uuid": "^2.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        }
       }
     },
     "term-size": {
@@ -10910,9 +10932,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
       "version": "2.0.0",
@@ -11300,6 +11322,11 @@
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
           }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "rethinkdb": "^2.3.3",
     "socket.io": "^2.1.0",
     "svg-to-png": "^3.1.2",
+    "uuid": "^3.3.2",
     "web3": "^1.0.0-beta.18",
     "web3-provider-engine": "^13.8.0",
     "xss": "^1.0.3"

--- a/src/api/logs.js
+++ b/src/api/logs.js
@@ -1,51 +1,83 @@
+const debug = require('debug')('app:api:logs')
 import resource from 'resource-router-middleware'
-
 import r from 'rethinkdb'
 import { toRes } from '../lib/util'
 
-export default ({ config, db, io }) =>
-  resource({
-    id: 'log',
 
-    load(req, id, callback) {
-      r.db('clovers_v2')
-        .table('logs')
-        .get(id)
-        .run(db, (err, log) => {
-          callback(err, log)
-        })
-    },
+export default ({ config, db, io }) => {
+  const id = 'log'
+  const load = (req, id, callback) => {
+    r.db('clovers_v2')
+      .table('logs')
+      .get(id)
+      .run(db, callback)
+  }
+  const router = resource({
+    id,
+    load,
 
-    index({ query }, res) {
-      let limit = parseInt(query.limit) || 50
-      let offset = parseInt(query.offset) || 0
-      limit = Math.min(limit, 150)
-      r.db('clovers_v2')
-        .table('logs')
-        .getAll('pub', { index: 'activity' })
-        .orderBy(r.desc('blockNumber'))
-        .slice(offset, offset + limit)
-        .run(db, toRes(res))
-    },
+    async index ({ query }, res) {
+      const pageSize = 24
+      const asc = query.asc === 'true'
+      const page = ((parseInt(query.page) || 1) - 1) * pageSize
+      const filter = !query.filter || query.filter === '' ? 'pub' : query.filter
+      const index = filter !== 'pub' ? 'name' : 'activity'
 
-    // create({ body }, res) {
-    //   res.json(body)
-    // },
+      let [results, count] = await Promise.all([
+        r.db('clovers_v2').table('logs')
+          .getAll(filter, { index })
+          .orderBy(asc ? r.asc('blockNumber') : r.desc('blockNumber'))
+          .slice(page, page + pageSize)
+          .run(db, (err, data) => {
+            if (err) throw new Error(err)
+            return data
+          }),
+        r.db('clovers_v2').table('logs')
+          .getAll(filter, { index })
+          .count().run(db, (err, data) => {
+            if (err) throw new Error(err)
+            return data
+          })
+      ]).catch((err) => {
+        debug('query error')
+        debug(err)
+      })
 
-    read({ log }, res) {
-      res.json(log)
-    },
+      const currentPage = parseInt(query.page) || 1
+      const hasNext = page + pageSize < count
 
-    // update({ log, body }, res) {
-    //   for (let key in body) {
-    //     if (key !== 'id') {
-    //       log[key] = body[key]
-    //     }
-    //   }
-    //   res.sendStatus(204)
-    // },
+      let response = {
+        page: currentPage,
+        allResults: count,
+        pageResults: results.length,
+        filterBy: filter,
+        orderBy: asc ? 'ascending' : 'descending',
+        prevPage: currentPage - 1 || false,
+        nextPage: hasNext ? currentPage + 1 : false,
+        results
+      }
 
-    // delete({ log }, res) {
-    //   res.sendStatus(204)
-    // }
+      const status = results.length ? 200 : 404
+
+      res.status(status).json(response).end()
+    }
   })
+
+  return router
+}
+
+// export function toRes(res, status = 200) {
+//   return (err, thing) => {
+//     if (err) return res.status(500).send(err)
+
+//     if (thing && typeof thing.toObject === 'function') {
+//       thing = thing.toObject()
+//     }
+//     thing
+//       .toArray()
+//       .then(results => {
+//         res.status(status).json(results)
+//       })
+//       .error(console.log)
+//   }
+// }

--- a/src/api/logs.js
+++ b/src/api/logs.js
@@ -41,6 +41,7 @@ export default ({ config, db, io }) => {
       ]).catch((err) => {
         debug('query error')
         debug(err)
+        return res.status(500).end()
       })
 
       const currentPage = parseInt(query.page) || 1
@@ -65,19 +66,3 @@ export default ({ config, db, io }) => {
 
   return router
 }
-
-// export function toRes(res, status = 200) {
-//   return (err, thing) => {
-//     if (err) return res.status(500).send(err)
-
-//     if (thing && typeof thing.toObject === 'function') {
-//       thing = thing.toObject()
-//     }
-//     thing
-//       .toArray()
-//       .then(results => {
-//         res.status(status).json(results)
-//       })
-//       .error(console.log)
-//   }
-// }

--- a/src/api/logs.js
+++ b/src/api/logs.js
@@ -20,12 +20,13 @@ export default ({ config, db, io }) => {
       const pageSize = 24
       const asc = query.asc === 'true'
       const page = ((parseInt(query.page) || 1) - 1) * pageSize
-      const filter = !query.filter || query.filter === '' ? 'pub' : query.filter
-      const index = filter !== 'pub' ? 'name' : 'activity'
+      const filter = !query.filter || query.filter === '' ? ['pub'] : query.filter.split(',')
+      const index = filter[0] !== 'pub' ? 'name' : 'activity'
+      debug('filter by', ...filter)
 
       let [results, count] = await Promise.all([
         r.db('clovers_v2').table('logs')
-          .getAll(filter, { index })
+          .getAll(...filter, { index })
           .orderBy(asc ? r.asc('blockNumber') : r.desc('blockNumber'))
           .slice(page, page + pageSize)
           .run(db, (err, data) => {
@@ -33,7 +34,7 @@ export default ({ config, db, io }) => {
             return data
           }),
         r.db('clovers_v2').table('logs')
-          .getAll(filter, { index })
+          .getAll(...filter, { index })
           .count().run(db, (err, data) => {
             if (err) throw new Error(err)
             return data

--- a/src/lib/build.js
+++ b/src/lib/build.js
@@ -30,14 +30,23 @@ const tables = [
         'activity',
         function (doc) {
           return r.branch(
-            r.expr(["ClubToken_Transfer","CurationMarket_Transfer"]).contains(doc("name")),
-            "priv",
-            "pub"
+            // log.name is not in this list
+            r.expr(['ClubToken_Transfer','CurationMarket_Transfer']).contains(doc('name')),
+            'priv',
+            r.branch(
+              doc('name').ne('Clovers_Transfer'),
+              'pub',
+              r.branch(
+                // not going to Clovers Contract
+                doc('data')('_to').ne('0x8A0011ccb1850e18A9D2D4b15bd7F9E9E423c11b'),
+                'pub',
+                'priv'
+              )
+            )
           )
         }
       ]
     ]
-    // index: 'transactionHash'
   },
   {
     name: 'orders',

--- a/src/socketing.js
+++ b/src/socketing.js
@@ -12,7 +12,7 @@ import r from 'rethinkdb'
 
 let io, db
 
-export var socketing = function({ _io, _db }) {
+export var socketing = function ({ _io, _db }) {
   io = _io
   db = _db
   var connections = 0
@@ -38,7 +38,7 @@ export var socketing = function({ _io, _db }) {
   beginListen('ClubTokenController')
 }
 
-async function beginListen(contract, key = 0) {
+async function beginListen (contract, key = 0) {
   let eventTypes = events[contract].eventTypes
   if (key > eventTypes.length - 1) return
   beginListen(contract, key + 1)
@@ -95,8 +95,14 @@ async function beginListen(contract, key = 0) {
   })
 }
 
-export var handleEvent = async function({ io, db, log }) {
-  io && io.emit('addEvent', log)
+const ignoredTypes = ['ClubToken_Transfer','CurationMarket_Transfer']
+
+export var handleEvent = async ({ io, db, log }) => {
+  if (io && !ignoredTypes.includes(log.name)) {
+    if (log.name !== 'Clovers_Transfer' || log.data._to !== '0x8A0011ccb1850e18A9D2D4b15bd7F9E9E423c11b') {
+      io.emit('newLog', log)
+    }
+  }
   let foo = log.name.split('_')
   let contract = foo[0]
   let name = foo[1]


### PR DESCRIPTION
New comments and Clover name changes add records to the `logs` table.

`/logs` endpoint supports pagination, descending or ascending (block number), and filtering by log name (eg `Clovers_Transfer`), and the API response includes this info along with the total results count.